### PR TITLE
Read config from `output.linkcheck2` rather than `output.linkcheck` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,9 @@ pages:
     - cp -r $BOOK_DIR/book/html public
   artifacts:
     paths:
-    - public
+      - public
   only:
     - master
 ```
 
-The [michaelfbryan/mdbook-docker-image][image] docker image is also available
-on Docker hub and comes with the latest version of `mdbook` and
-`mdbook-linkcheck` pre-installed.
-
-[releases]: https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases
 [mdbook-ci]: https://rust-lang.github.io/mdBook/continuous-integration.html
-[Michael-F-Bryan]: https://github.com/Michael-F-Bryan
-[image]: https://hub.docker.com/r/michaelfbryan/mdbook-docker-image

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ warning-policy = "warn"
 # the "Accept: text/html" header
 'crates\.io' = ["Accept: text/html"]
 
-# mdbook-linkcheck will interpolate environment variables into your header via
+# mdbook-linkcheck2 will interpolate environment variables into your header via
 # $IDENT.
 #
 # If this is not what you want you must escape the `$` symbol, like `\$TOKEN`.
@@ -111,7 +111,7 @@ warning-policy = "warn"
 
 ## Continuous Integration
 
-Incorporating `mdbook-linkcheck` into your CI system should be straightforward
+Incorporating `mdbook-linkcheck2` into your CI system should be straightforward
 if you are already [using `mdbook` to generate documentation][mdbook-ci].
 
 For those using GitLab's built-in CI:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ authors = ["Michael-F-Bryan"]
 
 [output.html]
 
-[output.linkcheck]
+[output.linkcheck2]
 ```
 
 And finally you should be able to run `mdbook build` like normal and everything
@@ -49,12 +49,12 @@ $ mdbook build
 ## Configuration
 
 The link checker's behaviour can be configured by setting options under the
-`output.linkcheck` table in your `book.toml`.
+`output.linkcheck2` table in your `book.toml`.
 
 ```toml
 ...
 
-[output.linkcheck]
+[output.linkcheck2]
 # Should we check links on the internet? Enabling this option adds a
 # non-negligible performance impact
 follow-web-links = false
@@ -92,7 +92,7 @@ warning-policy = "warn"
 # This is a dictionary (map), with keys being regexes
 # matching a set of web sites, and values being an array of
 # the headers.
-[output.linkcheck.http-headers]
+[output.linkcheck2.http-headers]
 # Any hyperlink that contains this regexp will be sent
 # the "Accept: text/html" header
 'crates\.io' = ["Accept: text/html"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,13 +110,13 @@ pub fn run(
     }
 }
 
-/// Get the configuration used by `mdbook-linkcheck`.
+/// Get the configuration used by `mdbook-linkcheck2`.
 pub fn get_config(cfg: &mdbook::Config) -> Result<Config, Error> {
-    match cfg.get("output.linkcheck") {
+    match cfg.get("output.linkcheck2") {
         Some(raw) => raw
             .clone()
             .try_into()
-            .context("Unable to deserialize the `output.linkcheck` table."),
+            .context("Unable to deserialize the `output.linkcheck2` table."),
         None => Ok(Config::default()),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ pub fn version_check(version: &str) -> Result<(), Error> {
         Ok(())
     } else {
         let msg = format!(
-            "mdbook-linkcheck isn't compatible with this version of mdbook ({} is not in the range {})",
+            "mdbook-linkcheck2 isn't compatible with this version of mdbook ({} is not in the range {})",
             found, constraints
         );
         Err(Error::msg(msg))

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -316,7 +316,7 @@ but users viewing the book from the file system may encounter broken links.
 To ignore this warning, you can edit `book.toml` and set the warning policy to
 "ignore".
 
-    [output.linkcheck]
+    [output.linkcheck2]
     warning-policy = "ignore"
 
 For more details, see https://github.com/Michael-F-Bryan/mdbook-linkcheck/issues/33

--- a/tests/all-green/book.toml
+++ b/tests/all-green/book.toml
@@ -4,7 +4,7 @@ multilingual = false
 src = "src"
 title = "All Green"
 
-[output.linkcheck]
+[output.linkcheck2]
 follow-web-links = true
 exclude = [".*nonexistent.*"]
 

--- a/tests/external-links/book.toml
+++ b/tests/external-links/book.toml
@@ -4,7 +4,7 @@ multilingual = false
 src = "src"
 title = "External links"
 
-[output.linkcheck]
+[output.linkcheck2]
 follow-web-links = false
 
 [output.html]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,7 +75,7 @@ where
 fn archive_name(outdir: &Path) -> Result<PathBuf, Error> {
     let BuildInfo { compiler, .. } = get_build_info();
 
-    let filename = format!("mdbook-linkcheck.{}.zip", compiler.host_triple);
+    let filename = format!("mdbook-linkcheck2.{}.zip", compiler.host_triple);
 
     Ok(outdir.join(filename))
 }
@@ -84,7 +84,7 @@ fn compile_binary() -> Result<PathBuf, Error> {
     let status = Command::new("cargo")
         .arg("build")
         .arg("--release")
-        .arg("--package=mdbook-linkcheck")
+        .arg("--package=mdbook-linkcheck2")
         .status()
         .context("Unable to invoke `cargo`")?;
     anyhow::ensure!(status.success(), "Cargo returned an error");
@@ -92,9 +92,9 @@ fn compile_binary() -> Result<PathBuf, Error> {
     let release_dir = TARGET_DIR.join("release");
 
     let filename = if cfg!(windows) {
-        "mdbook-linkcheck.exe"
+        "mdbook-linkcheck2.exe"
     } else {
-        "mdbook-linkcheck"
+        "mdbook-linkcheck2"
     };
     let binary = release_dir.join(filename);
     log::info!("Compiled to \"{}\"", binary.display());


### PR DESCRIPTION
This needs to match the name of the binary, as mdbook uses the name of the config section to determine which binary to invoke.

This fixes #2, and tidies up a few other references to the old name.